### PR TITLE
skip chunk if already in place

### DIFF
--- a/target.h
+++ b/target.h
@@ -18,6 +18,8 @@ struct target *target_new(const char *path);
 
 int target_write(struct target *t, const uint8_t *data, size_t len, off_t offset, const uint8_t *id);
 
+int target_check_chunk(struct target *t, uint8_t *tmp, size_t len, off_t offset, const uint8_t *id);
+
 static inline struct store *target_as_store(struct target *t)
 {
 	t->queryable = true;


### PR DESCRIPTION
I just noticed that I have reimplemented what you already started two years ago in your read-before-write branch. The commit calculates the hash of a chunk before it tries to fetch the chunk from a source.

What was missing in your branch is the handling of `last_id`. Since checking a target chunk overwrites the buffer, `have_last_id` must be updated. To not let the previous chunk go to waste, I skip checking the target and always write the chunk if `last_id` matches.

The code for adding a chunk to the index is moved to a separate function to be reused. I do not print any statistics about the skipped chunks.